### PR TITLE
Update visual template for babel

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+## 2.0.0
+* Update visual template.
+
+    Note: `window` object injection required;
+* The plugin clears `drop` folder - fixed.
+
+## 1.x.x
+* PowerBI Custom Visuals webpack plugin release. Fix bugs

--- a/extractor/js.js
+++ b/extractor/js.js
@@ -27,7 +27,7 @@ module.exports = async function(options, compilation) {
 		}
 	}
 
-	if (options.externalJS) {
+	if (options.externalJS && options.externalJS.length) {
 		sourcePromises.push(appendExternalJS(options.externalJS));
 		sourcePromises.push(Promise.resolve("var globalPowerbi = powerbi;"));
 	}

--- a/extractor/localization.js
+++ b/extractor/localization.js
@@ -53,6 +53,9 @@ const parseFromFolder = async function(options) {
 };
 
 module.exports = async function(options) {
+	if (options.devMode) {
+		return;
+	}
 	return Promise.all([
 		parseFromProperty(options),
 		parseFromFolder(options)

--- a/index.js
+++ b/index.js
@@ -288,8 +288,6 @@ class PowerBICustomVisualsWebpackPlugin {
 			icon: "assets/icon.png"
 		};
 
-		await fs.emptyDir(dropPath);
-
 		operations.push(
 			fs.outputFile(
 				path.join(dropPath, "package.json"),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-webpack-plugin",
-  "version": "1.0.15",
+  "version": "2.0.0",
   "description": "PowerBI Custom Visuals webpack plugin",
   "main": "index.js",
   "keywords": [

--- a/templates/plugin.ts.template
+++ b/templates/plugin.ts.template
@@ -1,5 +1,6 @@
 import { <%= visualClass %> } from "<%= visualSourceLocation %>";
-declare var powerbi;
+var powerbiKey = "powerbi";
+var powerbi = window[powerbiKey];
 powerbi.visuals = powerbi.visuals || {};
 powerbi.visuals.plugins = powerbi.visuals.plugins || {};
 powerbi.visuals.plugins["<%= pluginName %>"] = {
@@ -8,7 +9,7 @@ powerbi.visuals.plugins["<%= pluginName %>"] = {
     class: '<%= visualClass %>',
     version: '<%= visualVersion %>',
     apiVersion: '<%= apiVersion %>',
-    create: (options) => {
+    create: function (options) {
         if (<%= visualClass %>) {
             return new <%= visualClass %>(options);
         }

--- a/templates/plugin.ts.template
+++ b/templates/plugin.ts.template
@@ -9,7 +9,7 @@ powerbi.visuals.plugins["<%= pluginName %>"] = {
     class: '<%= visualClass %>',
     version: '<%= visualVersion %>',
     apiVersion: '<%= apiVersion %>',
-    create: function (options) {
+    create: (options) => {
         if (<%= visualClass %>) {
             return new <%= visualClass %>(options);
         }
@@ -18,5 +18,3 @@ powerbi.visuals.plugins["<%= pluginName %>"] = {
     },
     custom: true
 };
-
-export default powerbi;


### PR DESCRIPTION
The plugin clears `drop` folder - fixed.
Add changelog