### PR TITLE
Define `powerbi` variable if it was not defined in `window` object.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 2.0.1
+* Define `powerbi` variable if it was not defined in `window` object.
+* Log in console JSON validation fails.
+
 ## 2.0.0
 * Update visual template.
 

--- a/extractor/capabilities.js
+++ b/extractor/capabilities.js
@@ -1,6 +1,7 @@
 const Ajv = require("ajv");
 const path = require("path");
 const fs = require("fs-extra");
+const logger = require("../logger");
 
 const getSchema = async function(options) {
 	if (options.capabilitiesSchema)
@@ -31,8 +32,10 @@ module.exports = async function(options) {
 	return Promise.all([getSchema(options), getContent]).then(
 		([schema, json]) => {
 			const ajv = new Ajv({ extendRefs: true });
-			const valid = ajv.compile(schema)(json);
+			const valid = ajv.validate(schema, json);
 			if (valid) return json;
+			ajv.errors.forEach(error => logger.error(error.message, error.dataPath));
+
 			throw new Error("Invalid capabilities");
 		}
 	);

--- a/extractor/dependencies.js
+++ b/extractor/dependencies.js
@@ -43,10 +43,10 @@ module.exports = async function(options) {
 
 	return Promise.all([getSchema(options), getContent]).then(
 		([schema, json]) => {
-			if (!json) return null;
 			const ajv = new Ajv({ extendRefs: true });
-			const valid = ajv.compile(schema)(json);
+			const valid = ajv.validate(schema, json);
 			if (valid) return json;
+			ajv.errors.forEach(error => logger.error(error.message, error.dataPath));
 
 			throw new Error("Invalid dependencies");
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-webpack-plugin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "PowerBI Custom Visuals webpack plugin",
   "main": "index.js",
   "keywords": [

--- a/templates/plugin.ts.template
+++ b/templates/plugin.ts.template
@@ -1,6 +1,9 @@
 import { <%= visualClass %> } from "<%= visualSourceLocation %>";
 var powerbiKey = "powerbi";
 var powerbi = window[powerbiKey];
+if (typeof window[powerbiKey] === "undefined") {
+    powerbi = window[powerbiKey] = {};
+}
 powerbi.visuals = powerbi.visuals || {};
 powerbi.visuals.plugins = powerbi.visuals.plugins || {};
 powerbi.visuals.plugins["<%= pluginName %>"] = {


### PR DESCRIPTION
Log in console JSON validation fails.