### PR TITLE
Adding support for Python script visuals / Fixing logic for replacing source files in scripts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## 2.1.3
+* Adding support for Python script visuals
+* Fixing logic for replacing source files in scripts
+
 ## 2.1.2
 * Fix loading R script into visuals
 

--- a/extractor/scriptVisual.js
+++ b/extractor/scriptVisual.js
@@ -20,6 +20,8 @@ const getContent = async filePath => {
 			replaceCount++;
 			matchListFileName = Pattern4FileName.exec(content);
 		}
+		
+		return content;
 	});
 };
 

--- a/extractor/scriptVisual.js
+++ b/extractor/scriptVisual.js
@@ -7,35 +7,23 @@ const MAX_IMPORT_R_MODULES = 100;
 const getContent = async filePath => {
 	const Pattern4FileName = /^[^#\n]*source\s*?\(\s*?['|"]([^()'"]*)['|"]\s*?\)/m;
 
-	return fs.readFile(filePath, ENCODING).then(content => {
-		const replacePromises = [];
+	return fs.readFile(filePath, ENCODING).then(async content => {
+		let replaceCount = 0;
 		let matchListFileName = Pattern4FileName.exec(content);
 		while (
-			replacePromises.length < MAX_IMPORT_R_MODULES &&
+			replaceCount < MAX_IMPORT_R_MODULES &&
 			matchListFileName !== null &&
 			matchListFileName.length >= 2
 		) {
-			replacePromises.push(
-				fs
-					.readFile(
-						path.join(process.cwd(), matchListFileName[1]),
-						ENCODING
-					)
-					.then(moduleContent => content =>
-						content.replace(Pattern4FileName, moduleContent)
-					)
-			);
+			const moduleContent = await fs.readFile(path.join(process.cwd(), matchListFileName[1]), ENCODING);
+			content = content.replace(Pattern4FileName, moduleContent);
+			replaceCount++;
 			matchListFileName = Pattern4FileName.exec(content);
 		}
-
-		return Promise.all(replacePromises).then(replacers => {
-			replacers.forEach(replacer => (content = replacer(content)));
-			return content;
-		});
 	});
 };
 
-const isRVisual = capabilities => {
+const isScriptVisual = capabilities => {
 	return (
 		capabilities &&
 		capabilities.dataViewMappings &&
@@ -44,8 +32,20 @@ const isRVisual = capabilities => {
 	);
 };
 
+const getFileExtension = (providerName) => {
+	providerName = providerName.toLowerCase();
+	switch (providerName) {
+		case "r":
+			return "r";
+		case "python":
+			return "py";
+		default:
+			return providerName;
+	}
+};
+
 const patchCababilities = async (options, capabilities) => {
-	if (!isRVisual(capabilities)) return Promise.resolve(capabilities);
+	if (!isScriptVisual(capabilities)) return Promise.resolve(capabilities);
 
 	const scriptResult = capabilities.dataViewMappings[0].scriptResult;
 	if (
@@ -56,7 +56,7 @@ const patchCababilities = async (options, capabilities) => {
 
 	const filePath = path.join(
 		process.cwd(),
-		"script." + scriptResult.script.scriptProviderDefault.toLowerCase()
+		"script." + getFileExtension(scriptResult.script.scriptProviderDefault)
 	);
 	const content = await getContent(filePath);
 	scriptResult.script.scriptSourceDefault = content;
@@ -65,6 +65,6 @@ const patchCababilities = async (options, capabilities) => {
 
 module.exports = {
 	getContent,
-	isRVisual,
+	isScriptVisual,
 	patchCababilities
 };

--- a/extractor/scriptVisual.js
+++ b/extractor/scriptVisual.js
@@ -2,7 +2,7 @@ const path = require("path");
 const fs = require("fs-extra");
 const { ENCODING } = require("../constants");
 
-const MAX_IMPORT_R_MODULES = 100;
+const MAX_IMPORT_MODULES = 100;
 
 const getContent = async filePath => {
 	const Pattern4FileName = /^[^#\n]*source\s*?\(\s*?['|"]([^()'"]*)['|"]\s*?\)/m;
@@ -11,7 +11,7 @@ const getContent = async filePath => {
 		let replaceCount = 0;
 		let matchListFileName = Pattern4FileName.exec(content);
 		while (
-			replaceCount < MAX_IMPORT_R_MODULES &&
+			replaceCount < MAX_IMPORT_MODULES &&
 			matchListFileName !== null &&
 			matchListFileName.length >= 2
 		) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const { ENCODING } = require("./constants");
 const logger = require("./logger");
 const getDependencies = require("./extractor/dependencies");
 const getCapabilities = require("./extractor/capabilities");
-const rvisual = require("./extractor/rvisual");
+const scriptVisual = require("./extractor/scriptVisual");
 const getJsContent = require("./extractor/js");
 const getCssContent = require("./extractor/css");
 const getLocalization = require("./extractor/localization");
@@ -109,7 +109,7 @@ class PowerBICustomVisualsWebpackPlugin {
 			getLocalization(options),
 			getDependencies(options),
 			getCapabilities(options).then(capabilities =>
-				rvisual.patchCababilities(options, capabilities)
+				scriptVisual.patchCababilities(options, capabilities)
 			),
 			getJsContent(options, compilation),
 			getCssContent(options, compilation)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powerbi-visuals-webpack-plugin",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "PowerBI Custom Visuals webpack plugin",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
- Making changes to enable support for Python custom visuals. Instead of using script provider name as extension, choose extension based on it. For R it worked because R is provider name and file extension is also .r, for Python it's .py 

- Fixing logic in source file replacement. Instead of creating promises and resolving in the end, wait for them inline. Issue with current approach is that promises don't get resolved immediately and we end up creating 100 promises (max import value) to replace same file. (Simple to verify with outputting count and file being replaced) 