### PR TITLE
Correcting the signature of the create method in visualPlugin.ts template

### DIFF
--- a/templates/plugin.ts.template
+++ b/templates/plugin.ts.template
@@ -10,12 +10,12 @@ var <%= pluginName %>: IVisualPlugin = {
     displayName: '<%= visualDisplayName %>',
     class: '<%= visualClass %>',
     apiVersion: '<%= apiVersion %>',
-    create: (options: VisualConstructorOptions) => {
+    create: (options?: VisualConstructorOptions) => {
         if (<%= visualClass %>) {
             return new <%= visualClass %>(options);
         }
 
-        console.error('Visual instance not found');
+        throw 'Visual instance not found';
     },
     custom: true
 };


### PR DESCRIPTION
With the current version I receive the following error when enabling `noImplicitAny`:
```
error  in /home/vsts/work/1/s/.tmp/precompile/visualPlugin.ts

[tsl] ERROR in /home/vsts/work/1/s/.tmp/precompile/visualPlugin.ts(13,5)
      TS2322: Type '(options: VisualConstructorOptions) => Visual | undefined' is not assignable to type '(options?: VisualConstructorOptions | undefined) => IVisual'.
    Type 'Visual | undefined' is not assignable to type 'IVisual'.
      Type 'undefined' is not assignable to type 'IVisual'.
```

Changing the method signature by throwing an error instead of console.error