### PR TITLE
feat: support dynamic {capabilities, dependencies} configs

### DIFF
--- a/src/extractor/capabilities.js
+++ b/src/extractor/capabilities.js
@@ -1,13 +1,13 @@
 const Ajv = require("ajv");
 const path = require("path");
-const fs = require("fs-extra");
 const logger = require("../logger");
+const utils = require("../utils");
 
 const getSchema = async function (options) {
 	if (options.capabilitiesSchema)
 		return Promise.resolve(options.capabilitiesSchema);
 
-	return fs.readJson(
+	return utils.safelyReadConfig(
 		path.join(options.schemaLocation, "schema.capabilities.json")
 	);
 };
@@ -16,7 +16,7 @@ module.exports = async function (options) {
 	let getContent;
 	switch (typeof options.capabilities) {
 		case "string": {
-			getContent = fs.readJson(
+			getContent = utils.safelyReadConfig(
 				path.join(process.cwd(), options.capabilities)
 			);
 			break;

--- a/src/extractor/dependencies.js
+++ b/src/extractor/dependencies.js
@@ -1,13 +1,13 @@
 const Ajv = require("ajv");
 const path = require("path");
-const fs = require("fs-extra");
 const logger = require("../logger");
+const utils = require("../utils");
 
 const getSchema = async function (options) {
 	if (options.dependenciesSchema)
 		return Promise.resolve(options.dependenciesSchema);
 
-	return fs.readJson(
+	return utils.safelyReadConfig(
 		path.join(options.schemaLocation, "schema.dependencies.json")
 	);
 };
@@ -18,8 +18,7 @@ module.exports = async function (options) {
 	let getContent;
 	switch (typeof options.dependencies) {
 		case "string": {
-			getContent = fs
-				.readJson(path.join(process.cwd(), options.dependencies))
+			getContent = utils.safelyReadConfig(path.join(process.cwd(), options.dependencies))
 				.catch((err) => {
 					if (err.code === "ENOENT") {
 						logger.warn(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,11 +1,46 @@
-module.exports = {
-	populateErrors: (errors, fileName, type) => {
-		if (!errors || errors.length) return;
+const fs = require('fs');
+const { ENCODING } = require('./constants');
+const { file } = require('jszip');
 
-		return errors.map((e) => ({
-			filename: fileName,
-			message: e.stack || "Unknown error",
-			type: type,
-		}));
-	},
+const safelyImport = async (filePath) => {
+	try {
+		const config = (await import(`file://${filePath}`)).default;
+		return config;
+	} catch (e) {
+		console.error(`Error importing JS config from ${filePath}`, e);
+		return null;
+	}
+};
+
+const safelyParse = (filePath) => {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, ENCODING));
+	}
+	catch (e) {
+		console.error(`Error parsing JSON config from ${filePath}`, e);
+		return null;
+	}
+};
+
+const safelyReadConfig = async (filePath) => {
+	return filePath.endsWith('js') ?
+		(await safelyImport(filePath)) :
+		safelyParse(filePath);
+};
+
+const populateErrors = (errors, fileName, type) => {
+	if (!errors || errors.length) return;
+
+	return errors.map((e) => ({
+		filename: fileName,
+		message: e.stack || "Unknown error",
+		type: type,
+	}));
+};
+
+module.exports = {
+	safelyImport,
+	safelyParse,
+	safelyReadConfig,
+	populateErrors
 };


### PR DESCRIPTION
### Summary
This PR adds dynamic `capabilities` and `dependencies` support to this repo.

### Context
Support for dynamic (JS-based) `pbiviz` configurations was added to `powerbi-visuals-tools` in [this PR](https://github.com/microsoft/PowerBI-visuals-tools/pull/534).

As it turns out, the team I'm working with _also_ needs support for dynamic `capabilities.js[on]` configurations when using `pbiviz`. Since `capabilities` are extracted and processed by this repo (and not `powerbi-visuals-tools`), I've made those changes here.

### Notes
> **Dependencies config**
> I went ahead and added dynamic configuration support for `dependencies` as well. To me, this seems like a good future-proofing measure.

> **Localization config**
> However - when I tried adding dynamic `localization` support to this package, that caused the `pbiviz` tests to fail. Our partner team doesn't need this feature, so in lieu of debugging this further I decided to omit it from this PR.
>
> _Note: the tests fail on [this line](https://github.com/microsoft/PowerBI-visuals-tools/blob/main/spec/e2e/pbivizPackageSpec.js#L314), because `pbivizJson.stringResources` has an extra `"ru-RU.json": null` property when using dynamic localization configs. I was unable to figure out why this property was added._